### PR TITLE
Toggle card color

### DIFF
--- a/JensensWebApp/wwwroot/css/site.css
+++ b/JensensWebApp/wwwroot/css/site.css
@@ -21,10 +21,10 @@ h1 {
 }
 
 card-body, p {
-    color:red;
+    color: black;
 }
 card-body, h5 {
-    color:green;
+    color: darkslategray;
 }
 
 html {
@@ -47,6 +47,7 @@ body {
 .card {
     background-color: white;
     color: black;
+    border-radius: 15px;
 }
 
 .dark-mode .articles-container {
@@ -55,6 +56,14 @@ body {
 
 .dark-mode .card {
     background-color: #495057;
+    color: white;
+}
+
+.dark-mode .card h5 {
+    color:rgb(171, 171, 171);
+}
+
+.dark-mode .card p {
     color: white;
 }
 
@@ -83,5 +92,5 @@ body {
 }
 
 .fixed-button:hover {
-    background-color: grey;
+    background-color: rgb(196, 196, 196);
 }

--- a/JensensWebApp/wwwroot/css/site.css
+++ b/JensensWebApp/wwwroot/css/site.css
@@ -77,10 +77,11 @@ body {
 
 .dark-mode .nav-link.text-dark{
     color: white !important;
-
+}
 .fixed-button {
     border: none;
 }
 
 .fixed-button:hover {
     background-color: grey;
+}


### PR DESCRIPTION
Cards that display the articles now also change the text to white, for easier reading during dark-mode